### PR TITLE
Build policy-bot from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,58 @@
 # FIXME: https://github.com/palantir/policy-bot/issues/558
-FROM alpine:latest AS build
 
-RUN apk add --no-cache github-cli
+# https://github.com/palantir/policy-bot/blob/develop/.palantir/go-version
+FROM golang:1.21.5-alpine3.19 AS build
 
-# https://github.com/palantir/policy-bot/actions/runs/5685648464
-ARG GH_RUN_ID=5685648464
+WORKDIR /src
 
-RUN --mount=type=secret,id=GITHUB_TOKEN \
-    GH_TOKEN=$(cat < /run/secrets/GITHUB_TOKEN) gh run download -R palantir/policy-bot ${GH_RUN_ID} \
-    && find dist -type f -name '*.tgz' | xargs tar -zxvf \
-    && ln -s $(find . -name 'policy-bot-*' -maxdepth 1) build \
-    && readlink -n build | awk -F'/' '{print $2}' > build/.version
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash git nodejs npm yarn curl wget
+
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+ENV CGO_ENABLED=0
+
+# renovate: datasource=github-releases depName=palantir/policy-bot
+ARG POLICY_BOT_VERSION=v1.31.0
+
+RUN git clone --depth 1 -c advice.detachedHead=false \
+	--branch "$POLICY_BOT_VERSION" https://github.com/palantir/policy-bot.git .
+
+# https://github.com/palantir/policy-bot/blob/develop/.github/workflows/build.yml
+
+# Install frontend dependencies
+# hadolint ignore=DL3059
+RUN yarn install
+
+# Build frontend
+# hadolint ignore=DL3059
+RUN yarn run build:production
+
+# Build distribution
+# hadolint ignore=DL3059
+RUN ./godelw dist
 
 # https://hub.docker.com/r/palantirtechnologies/policy-bot
 # https://github.com/palantir/policy-bot/blob/develop/docker/Dockerfile
-FROM alpine
-
-STOPSIGNAL SIGINT
-
-ARG TARGERTARCH=arm64
-ENV TARGERTARCH ${TARGERTARCH}
+FROM alpine:3.19
 
 WORKDIR /policy-bot
 
-COPY --from=build build/ .
-
-RUN ln -s $(pwd)/bin/linux-${TARGERTARCH}/policy-bot $(pwd)/bin/policy-bot
-
+COPY --from=build /src/build/policy-bot/*/bin/policy-bot-*.tgz ./policy-bot.tgz
 # add the default configuration file
-COPY src/config/policy-bot.example.yml /secrets/policy-bot.yml
+COPY --from=build /src/config/policy-bot.example.yml /secrets/policy-bot.yml
+
+ARG TARGETARCH
+
+RUN tar -zxvf policy-bot.tgz --strip-components=1 && \
+	ln -s "$(pwd)/bin/linux-${TARGETARCH}/policy-bot" "$(pwd)/bin/policy-bot" && \
+	rm policy-bot.tgz
 
 COPY src/docker/ca-certificates.crt /etc/ssl/certs/
 COPY src/docker/mime.types /etc/
 
-ENTRYPOINT ["bin/policy-bot"]
-CMD ["server", "--config", "/secrets/policy-bot.yml"]
+RUN bin/policy-bot --help
+
+ENTRYPOINT [ "bin/policy-bot" ]
+CMD [ "server", "--config", "/secrets/policy-bot.yml" ]
+STOPSIGNAL SIGINT


### PR DESCRIPTION
The actions run we were depending on to download
the arm64 distribution files has expired, so instead we can build from source using the upstream Dockerfile and GitHub workflows as examples.

Change-type: patch